### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qwlroots (0.3.0-deepin0) unstable; urgency=medium
+
+ * Sync upstream code
+
+ -- Dingyuan Zhang <zhangdingyuan@uniontech.com>  Fri, 23 Aug 2024 10:01:00 +0800
+
 qwlroots (0.2.0-alpha2+git+20240808-deepin) unstable; urgency=medium
 
  * Sync upstream code

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-qwlroots (0.3.0-deepin0) unstable; urgency=medium
+qwlroots (0.3.0-deepin+1) unstable; urgency=medium
 
  * Sync upstream code
 


### PR DESCRIPTION
upstream tag
https://github.com/vioken/qwlroots/releases/tag/0.3.0-wlroots0.17-0.18

Log: